### PR TITLE
Fix removeAllListeners type error

### DIFF
--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -1,0 +1,175 @@
+// Node.js events module polyfill for browser environment
+// This provides the missing events functionality that @huggingface/transformers expects
+
+export class EventEmitter {
+  private events: { [key: string]: Function[] } = {};
+  private maxListeners: number = 10;
+
+  on(event: string, listener: Function): this {
+    if (!this.events[event]) {
+      this.events[event] = [];
+    }
+    
+    // Check max listeners
+    if (this.events[event].length >= this.maxListeners) {
+      console.warn(`MaxListenersExceededWarning: Possible EventEmitter memory leak detected. ${this.events[event].length} listeners added. Use emitter.setMaxListeners() to increase limit`);
+    }
+    
+    this.events[event].push(listener);
+    return this;
+  }
+
+  addListener(event: string, listener: Function): this {
+    return this.on(event, listener);
+  }
+
+  once(event: string, listener: Function): this {
+    const onceWrapper = (...args: any[]) => {
+      listener.apply(this, args);
+      this.off(event, onceWrapper);
+    };
+    return this.on(event, onceWrapper);
+  }
+
+  off(event: string, listener: Function): this {
+    return this.removeListener(event, listener);
+  }
+
+  removeListener(event: string, listener: Function): this {
+    if (!this.events[event]) return this;
+    
+    const index = this.events[event].indexOf(listener);
+    if (index > -1) {
+      this.events[event].splice(index, 1);
+    }
+    return this;
+  }
+
+  removeAllListeners(event?: string): this {
+    if (event) {
+      delete this.events[event];
+    } else {
+      this.events = {};
+    }
+    return this;
+  }
+
+  emit(event: string, ...args: any[]): boolean {
+    if (!this.events[event]) return false;
+    
+    // Create a copy of the listeners array to avoid issues if listeners are removed during emission
+    const listeners = [...this.events[event]];
+    
+    listeners.forEach(listener => {
+      try {
+        listener.apply(this, args);
+      } catch (error) {
+        console.error('EventEmitter error:', error);
+      }
+    });
+    
+    return true;
+  }
+
+  listenerCount(event: string): number {
+    return this.events[event] ? this.events[event].length : 0;
+  }
+
+  eventNames(): string[] {
+    return Object.keys(this.events);
+  }
+
+  setMaxListeners(n: number): this {
+    this.maxListeners = n;
+    return this;
+  }
+
+  getMaxListeners(): number {
+    return this.maxListeners;
+  }
+
+  listeners(event: string): Function[] {
+    return this.events[event] ? [...this.events[event]] : [];
+  }
+
+  rawListeners(event: string): Function[] {
+    return this.listeners(event);
+  }
+
+  prependListener(event: string, listener: Function): this {
+    if (!this.events[event]) {
+      this.events[event] = [];
+    }
+    this.events[event].unshift(listener);
+    return this;
+  }
+
+  prependOnceListener(event: string, listener: Function): this {
+    const onceWrapper = (...args: any[]) => {
+      listener.apply(this, args);
+      this.off(event, onceWrapper);
+    };
+    return this.prependListener(event, onceWrapper);
+  }
+}
+
+// Create a default export for the events module
+const events = {
+  EventEmitter,
+  once: (emitter: EventEmitter, event: string): Promise<any[]> => {
+    return new Promise((resolve) => {
+      emitter.once(event, (...args) => resolve(args));
+    });
+  },
+  on: (emitter: EventEmitter, event: string): AsyncIterableIterator<any[]> => {
+    const queue: any[][] = [];
+        let resolve: ((value: IteratorResult<any[]>) => void) | null = null;
+        let reject: ((reason: any) => void) | null = null;
+
+        const listener = (...args: any[]) => {
+          if (resolve) {
+            resolve({ value: args, done: false });
+            resolve = null;
+          } else {
+            queue.push(args);
+          }
+        };
+
+        emitter.on(event, listener);
+
+        const iterator: AsyncIterableIterator<any[]> = {
+          [Symbol.asyncIterator]() {
+            return iterator;
+          },
+          async next() {
+            if (queue.length > 0) {
+              return { value: queue.shift()!, done: false };
+            }
+            return new Promise((res, rej) => {
+              resolve = res;
+              reject = rej;
+            });
+          },
+          async return() {
+            emitter.off(event, listener);
+            if (reject) reject(new Error('Iterator cancelled'));
+            return { value: undefined, done: true };
+          },
+          async throw(error) {
+            emitter.off(event, listener);
+            if (reject) reject(error);
+            throw error;
+          }
+        };
+
+        return iterator;
+  }
+};
+
+// Make events available globally for the transformers library
+if (typeof window !== 'undefined') {
+  (window as any).EventEmitter = EventEmitter;
+  (window as any).events = events;
+}
+
+export default events;

--- a/src/lib/polyfills.ts
+++ b/src/lib/polyfills.ts
@@ -1,0 +1,178 @@
+// Comprehensive polyfills for Node.js compatibility in browser environment
+// This ensures @huggingface/transformers works properly in the browser
+
+// Import the events polyfill
+import './events';
+
+// Polyfill global variables that Node.js expects
+if (typeof window !== 'undefined') {
+  // Ensure global is available
+  if (!(window as any).global) {
+    (window as any).global = window;
+  }
+
+  // Polyfill process if not available
+  if (!(window as any).process) {
+    (window as any).process = {
+      env: {
+        NODE_ENV: process.env.NODE_ENV || 'development',
+      },
+      browser: true,
+      version: '',
+      versions: {},
+      platform: 'browser',
+      arch: 'x64',
+      cwd: () => '/',
+      nextTick: (callback: Function) => Promise.resolve().then(callback),
+    };
+  }
+
+  // Polyfill Buffer if not available
+  if (!(window as any).Buffer) {
+    (window as any).Buffer = {
+      from: (data: any, encoding?: string) => {
+        if (typeof data === 'string') {
+          return new TextEncoder().encode(data);
+        }
+        return data;
+      },
+      alloc: (size: number) => new Uint8Array(size),
+      allocUnsafe: (size: number) => new Uint8Array(size),
+      isBuffer: (obj: any) => obj instanceof Uint8Array,
+    };
+  }
+
+  // Polyfill util if not available
+  if (!(window as any).util) {
+    (window as any).util = {
+      inherits: (ctor: any, superCtor: any) => {
+        ctor.super_ = superCtor;
+        Object.setPrototypeOf(ctor.prototype, superCtor.prototype);
+      },
+      format: (format: string, ...args: any[]) => {
+        return format.replace(/%s/g, () => args.shift() || '');
+      },
+      inspect: (obj: any) => JSON.stringify(obj, null, 2),
+    };
+  }
+
+  // Polyfill stream if not available
+  if (!(window as any).stream) {
+    (window as any).stream = {
+      Readable: class Readable {
+        constructor() {
+          throw new Error('Stream.Readable not implemented in browser');
+        }
+      },
+      Writable: class Writable {
+        constructor() {
+          throw new Error('Stream.Writable not implemented in browser');
+        }
+      },
+      Transform: class Transform {
+        constructor() {
+          throw new Error('Stream.Transform not implemented in browser');
+        }
+      },
+    };
+  }
+
+  // Polyfill fs if not available
+  if (!(window as any).fs) {
+    (window as any).fs = {
+      readFileSync: () => {
+        throw new Error('fs.readFileSync not available in browser');
+      },
+      writeFileSync: () => {
+        throw new Error('fs.writeFileSync not available in browser');
+      },
+      existsSync: () => false,
+      mkdirSync: () => {
+        throw new Error('fs.mkdirSync not available in browser');
+      },
+    };
+  }
+
+  // Polyfill path if not available
+  if (!(window as any).path) {
+    (window as any).path = {
+      join: (...parts: string[]) => parts.join('/'),
+      resolve: (...parts: string[]) => parts.join('/'),
+      dirname: (path: string) => path.split('/').slice(0, -1).join('/'),
+      basename: (path: string) => path.split('/').pop() || '',
+      extname: (path: string) => {
+        const parts = path.split('.');
+        return parts.length > 1 ? '.' + parts.pop() : '';
+      },
+    };
+  }
+
+  // Polyfill os if not available
+  if (!(window as any).os) {
+    (window as any).os = {
+      platform: () => 'browser',
+      arch: () => 'x64',
+      cpus: () => [],
+      freemem: () => 0,
+      totalmem: () => 0,
+      homedir: () => '/',
+      tmpdir: () => '/tmp',
+    };
+  }
+
+  // Polyfill crypto if not available (use Web Crypto API)
+  if (!(window as any).crypto) {
+    (window as any).crypto = window.crypto || {
+      getRandomValues: (array: Uint8Array) => {
+        for (let i = 0; i < array.length; i++) {
+          array[i] = Math.floor(Math.random() * 256);
+        }
+        return array;
+      },
+    };
+  }
+
+  // Polyfill url if not available
+  if (!(window as any).url) {
+    (window as any).url = {
+      URL: window.URL,
+      URLSearchParams: window.URLSearchParams,
+    };
+  }
+
+  // Polyfill querystring if not available
+  if (!(window as any).querystring) {
+    (window as any).querystring = {
+      parse: (str: string) => {
+        const params = new URLSearchParams(str);
+        const result: any = {};
+        for (const [key, value] of params) {
+          result[key] = value;
+        }
+        return result;
+      },
+      stringify: (obj: any) => {
+        const params = new URLSearchParams();
+        for (const [key, value] of Object.entries(obj)) {
+          params.append(key, String(value));
+        }
+        return params.toString();
+      },
+    };
+  }
+}
+
+// Export the polyfills for manual import if needed
+export const polyfills = {
+  events: true,
+  process: true,
+  buffer: true,
+  util: true,
+  stream: true,
+  fs: true,
+  path: true,
+  os: true,
+  crypto: true,
+  url: true,
+  querystring: true,
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// Import comprehensive polyfills before anything else
+import './lib/polyfills';
+
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'

--- a/src/services/nlpSummarizer.ts
+++ b/src/services/nlpSummarizer.ts
@@ -1,3 +1,5 @@
+// Import comprehensive polyfills first
+import '../lib/polyfills';
 import { pipeline } from '@huggingface/transformers';
 
 // Define a type for the summarizer pipeline
@@ -20,6 +22,12 @@ export class NLPSummarizer {
       await Promise.race([
         (async () => {
           try {
+            // Ensure polyfills are available globally
+            if (typeof window !== 'undefined' && !(window as any).EventEmitter) {
+              console.warn('Polyfills not available, importing comprehensive polyfills');
+              await import('../lib/polyfills');
+            }
+
             // Suppress console warnings during initialization
             const originalWarn = console.warn;
             const originalError = console.error;

--- a/test-polyfill.html
+++ b/test-polyfill.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EventEmitter Polyfill Test</title>
+</head>
+<body>
+    <h1>EventEmitter Polyfill Test</h1>
+    <div id="output"></div>
+
+    <script type="module">
+        // Import the polyfills
+        import('./src/lib/polyfills.js');
+        
+        // Test EventEmitter functionality
+        setTimeout(() => {
+            const output = document.getElementById('output');
+            
+            try {
+                // Test if EventEmitter is available
+                if (window.EventEmitter) {
+                    output.innerHTML += '<p style="color: green;">✓ EventEmitter is available</p>';
+                    
+                    // Test basic EventEmitter functionality
+                    const emitter = new window.EventEmitter();
+                    
+                    // Test on and emit
+                    let testPassed = false;
+                    emitter.on('test', (data) => {
+                        testPassed = data === 'success';
+                    });
+                    
+                    emitter.emit('test', 'success');
+                    
+                    if (testPassed) {
+                        output.innerHTML += '<p style="color: green;">✓ EventEmitter.on and emit work correctly</p>';
+                    } else {
+                        output.innerHTML += '<p style="color: red;">✗ EventEmitter.on and emit failed</p>';
+                    }
+                    
+                    // Test removeAllListeners
+                    try {
+                        emitter.removeAllListeners();
+                        output.innerHTML += '<p style="color: green;">✓ removeAllListeners works correctly</p>';
+                    } catch (error) {
+                        output.innerHTML += '<p style="color: red;">✗ removeAllListeners failed: ' + error.message + '</p>';
+                    }
+                    
+                    // Test other Node.js globals
+                    if (window.process) {
+                        output.innerHTML += '<p style="color: green;">✓ process polyfill is available</p>';
+                    } else {
+                        output.innerHTML += '<p style="color: red;">✗ process polyfill is missing</p>';
+                    }
+                    
+                    if (window.Buffer) {
+                        output.innerHTML += '<p style="color: green;">✓ Buffer polyfill is available</p>';
+                    } else {
+                        output.innerHTML += '<p style="color: red;">✗ Buffer polyfill is missing</p>';
+                    }
+                    
+                } else {
+                    output.innerHTML += '<p style="color: red;">✗ EventEmitter is not available</p>';
+                }
+            } catch (error) {
+                output.innerHTML += '<p style="color: red;">✗ Error: ' + error.message + '</p>';
+            }
+        }, 100);
+    </script>
+</body>
+</html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,6 +18,15 @@ export default defineConfig(({ mode }) => ({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      // Polyfill Node.js modules for browser compatibility
+      "events": path.resolve(__dirname, "./src/lib/events.ts"),
     },
+  },
+  define: {
+    // Ensure global variables are available
+    global: 'globalThis',
+  },
+  optimizeDeps: {
+    include: ['@huggingface/transformers'],
   },
 }));


### PR DESCRIPTION
Add Node.js polyfills to resolve `removeAllListeners is not a function` error in the browser environment.

The `@huggingface/transformers` library, used for NLP summarization, attempts to use Node.js's EventEmitter methods (like `removeAllListeners`) which are not natively available in a browser. This PR introduces comprehensive polyfills for `events`, `process`, `Buffer`, and other Node.js globals to ensure the library functions correctly in the browser.

---
<a href="https://cursor.com/background-agent?bcId=bc-79d6b68a-62da-4181-9848-0102eb5f6fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79d6b68a-62da-4181-9848-0102eb5f6fe1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

